### PR TITLE
Add arm64 support

### DIFF
--- a/.github/workflows/push_to_docker.yml
+++ b/.github/workflows/push_to_docker.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64, linux/arm64
           push: true
           tags: |
             ghcr.io/${{ env.OWNER_LC }}/jellyfin-auto-collections:latest


### PR DESCRIPTION
A little change in the Github Actions file that lets people use arm64 devices (e.g., Raspberry Pi) without having to manually build the Docker image.