### PR TITLE
Unbuffer print commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ COPY --from=build /app /app
 
 VOLUME [ "/app/config" ]
 
-ENTRYPOINT [ "python3.10", "main.py", "--config", "/app/config/config.yaml" ]
+ENTRYPOINT [ "python3.10", "-u", "main.py", "--config", "/app/config/config.yaml" ]


### PR DESCRIPTION
`print()` in Python will eventually show up in docker logs, but only after some has build up. Making print unbuffered allows for more immediate printing.

Applies to both 2 and 3:
https://stackoverflow.com/questions/29663459/why-doesnt-python-app-print-anything-when-run-in-a-detached-docker-container

This should address #57 
It is probably better to rewrite the `print()` functions to use `logging` instead, but that requires more work than this (and can still be done later).