### PR TITLE
Support Trakt Watchlist/Favorites

### DIFF
--- a/plugins/trakt.py
+++ b/plugins/trakt.py
@@ -136,7 +136,7 @@ class Trakt(ListScraper):
         logger.debug("Access token loaded")
 
         if list_id.startswith("users/"):
-            logger.debug("Trakt Private User list")
+            logger.debug("Trakt Default User list")
             r = requests.get(f"https://api.trakt.tv/{list_id}", headers=headers)
             components = list_id.split("/")
             list_name = f"{components[1]}'s {components[2]}"
@@ -156,7 +156,7 @@ class Trakt(ListScraper):
 
             items_data = r.json()
         else:
-            logger.debug("Trakt Public User list")
+            logger.debug("Trakt User list")
             r = requests.get(f"https://api.trakt.tv/lists/{list_id}", headers=headers)
             list_name = r.json()["name"]
             description = r.json()["description"]

--- a/plugins/trakt.py
+++ b/plugins/trakt.py
@@ -135,7 +135,7 @@ class Trakt(ListScraper):
         headers["Authorization"] = f"Bearer {access_token}"
         logger.debug("Access token loaded")
 
-        if list_id.startswith("users"):
+        if list_id.startswith("users/"):
             logger.debug("Trakt Private User list")
             r = requests.get(f"https://api.trakt.tv/{list_id}", headers=headers)
             components = list_id.split("/")

--- a/plugins/trakt.py
+++ b/plugins/trakt.py
@@ -135,7 +135,13 @@ class Trakt(ListScraper):
         headers["Authorization"] = f"Bearer {access_token}"
         logger.debug("Access token loaded")
 
-        if list_id.startswith("shows/") or list_id.startswith("movies/"):
+        if list_id.startswith("users"):
+            r = requests.get(f"https://api.trakt.tv/{list_id}", headers=headers)
+            components = list_id.split("/")
+            list_name = f"{components[1]}'s {components[2]}"
+            description = f"{components[1]}'s {components[2]}"
+            items_data = r.json()
+        elif list_id.startswith("shows/") or list_id.startswith("movies/"):
             # Chart
             logger.debug("Trakt chart list")
             r = requests.get(f"https://api.trakt.tv/{list_id}", headers=headers)

--- a/plugins/trakt.py
+++ b/plugins/trakt.py
@@ -136,6 +136,7 @@ class Trakt(ListScraper):
         logger.debug("Access token loaded")
 
         if list_id.startswith("users"):
+            logger.debug("Trakt Private User list")
             r = requests.get(f"https://api.trakt.tv/{list_id}", headers=headers)
             components = list_id.split("/")
             list_name = f"{components[1]}'s {components[2]}"
@@ -155,7 +156,7 @@ class Trakt(ListScraper):
 
             items_data = r.json()
         else:
-            logger.debug("Trakt User list")
+            logger.debug("Trakt Public User list")
             r = requests.get(f"https://api.trakt.tv/lists/{list_id}", headers=headers)
             list_name = r.json()["name"]
             description = r.json()["description"]


### PR DESCRIPTION
This PR adds support for `"users/xyz/favorites` and `"users/xyz/watchlist` to the trakt plugin, for accessing those built-in lists