### PR TITLE
Fix Jellyseerr request bug

### DIFF
--- a/utils/jellyseerr.py
+++ b/utils/jellyseerr.py
@@ -65,7 +65,7 @@ class JellyseerrClient:
             elif "releaseDate" in result:
                 # Try year match
                 release_year = result["releaseDate"].split("-")[0]
-                if release_year == str(item["release_year"]):
+                if release_year == str(item["release_year"]).strip():
                     mediaId = result["id"]
                     logger.debug(f"Found year match for {item['title']}")
                     break


### PR DESCRIPTION
The letterbox plugin returns movies with whitespace around the year, e.g. ' 2019 '. The Jellyseerr util matches based on the year which, as it's a simple string match, will fail for letterbox movies. This fixes that by stripping whitespace before doing the comparison.