### PR TITLE
(feat) save trakt token in /app/config volume to persist token across container restarts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,9 @@ RUN apk update
 FROM base AS build
 
 WORKDIR /app
-COPY . .
+COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt
+COPY . .
 
 FROM build AS final
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,17 @@
-FROM python:3.10-alpine as base
+FROM python:3.10-alpine AS base
 
 LABEL org.opencontainers.image.source https://github.com/ghomasHudson/jellyfin-auto-collections
 
 ENV RUNNING_IN_DOCKER true
 
 RUN apk update
-FROM base as build
+FROM base AS build
 
 WORKDIR /app
 COPY . .
 RUN pip install -r requirements.txt
 
-FROM build as final
+FROM build AS final
 
 WORKDIR /app
 COPY --from=build /app /app

--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ import sys
 
 from apscheduler.schedulers.blocking import BlockingScheduler
 from apscheduler.triggers.cron import CronTrigger
-
+from pathlib import Path
 import argparse
 parser = argparse.ArgumentParser(description='Jellyfin List Scraper')
 parser.add_argument('--config', type=str, help='Path to config file', default='config.yaml')
@@ -20,6 +20,8 @@ log_level = os.getenv("LOG_LEVEL", "INFO").upper()
 # Configure Loguru logger
 logger.remove()  # Remove default configuration
 logger.add(sys.stderr, level=log_level)
+
+working_directory = Path("/app/config") if os.getenv("RUNNING_IN_DOCKER", "").lower() == "true" else Path.cwd()
 
 # Load config
 if not os.path.exists(args.config):

--- a/main.py
+++ b/main.py
@@ -9,7 +9,6 @@ import sys
 
 from apscheduler.schedulers.blocking import BlockingScheduler
 from apscheduler.triggers.cron import CronTrigger
-from pathlib import Path
 import argparse
 parser = argparse.ArgumentParser(description='Jellyfin List Scraper')
 parser.add_argument('--config', type=str, help='Path to config file', default='config.yaml')
@@ -20,8 +19,6 @@ log_level = os.getenv("LOG_LEVEL", "INFO").upper()
 # Configure Loguru logger
 logger.remove()  # Remove default configuration
 logger.add(sys.stderr, level=log_level)
-
-working_directory = Path("/app/config") if os.getenv("RUNNING_IN_DOCKER", "").lower() == "true" else Path.cwd()
 
 # Load config
 if not os.path.exists(args.config):

--- a/plugins/trakt.py
+++ b/plugins/trakt.py
@@ -5,11 +5,11 @@ import os
 import requests
 from loguru import logger
 import time
-
+from main import working_directory
 class Trakt(ListScraper):
 
     _alias_ = 'trakt'
-    _access_token_file = '.trakt_access_token'
+    _access_token_file = str(working_directory) + '/.trakt_access_token'
 
     _chart_types = {
             "movies/trending": {
@@ -89,7 +89,7 @@ class Trakt(ListScraper):
             # If we have already authenticated, read the access token from the file
             with open(Trakt._access_token_file, 'r') as f:
                 access_token = f.read()
-            logger.debug("Existing access token found")
+            logger.debug(f"Existing access token found at {Trakt._access_token_file}")
         else:
             # If we have not authenticated, get the access token from the user
             r = requests.post("https://api.trakt.tv/oauth/device/code", headers=headers, json={"client_id": config["client_id"]})

--- a/plugins/trakt.py
+++ b/plugins/trakt.py
@@ -5,11 +5,12 @@ import os
 import requests
 from loguru import logger
 import time
-from main import working_directory
+from pathlib import Path
 class Trakt(ListScraper):
 
     _alias_ = 'trakt'
-    _access_token_file = str(working_directory) + '/.trakt_access_token'
+    _working_directory = Path("/app/config") if os.getenv("RUNNING_IN_DOCKER", "").lower() == "true" else Path.cwd()
+    _access_token_file = str(_working_directory) + '/.trakt_access_token'
 
     _chart_types = {
             "movies/trending": {


### PR DESCRIPTION
This PR saves the trakt token in `/app/config` when the app is run in a container, uses the current working directory otherwise

fixes #120, #99

