### PR TITLE
Updates to prevent jellyfin database panic, added fallback logic for plugins that fail, and added remove image functionality.

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -31,31 +31,6 @@ plugins:
       - ls055592025
       - ls068305490
       - ls087301829
-  trakt:
-    enabled: false
-    clear_poster: true      #Clears poster before importing items (causes new generation)
-    clear_collection: true  #Clears collection before importing items
-    max_items: 20           #Sets a limit of the number of items pulled from Trakt. It does not take into account if finds a match for the item. if not set it pulls all.
-    list_ids:
-      - movies/trending     #The most watched movies right now.
-      - movies/popular      #The most popular movies of all time.
-      - movies/favorited    #The most favorited movies for the last week.
-      - movies/watched      #The most watched movies for the last week.
-      - movies/collected    #The most collected movies for the last week.
-      - movies/played       #The most played movies for the last week.
-      - movies/anticipated  #The most anticipated movies based on the number of lists a movie appears on.
-      - movies/boxoffice    #The top 10 movies in the US box office last weekend.
-      - shows/trending      #The most watched shows right now.
-      - shows/popular       #The most popular shows of all time. Popularity is calculated using the rating percentage and the number of ratings.
-      - shows/favorited     #The most favorited shows for the last week.
-      - shows/watched       #The most watched shows for the last week.
-      - shows/collected     #Most Collected Shows
-      - shows/played        #The most played (a single user can watch multiple episodes multiple times) shows for the last week.
-      - shows/anticipated   #The most anticipated shows based on the number of lists a show appears on.
-      - users/draackje/lists/pixar-feature-films # Add user lists by adding the last part of the url (if private it has to be the same user that has the api)
-      #- 20124699          # Custom list ID for a user's list. (deprecated)
-    client_id: aaaaaaa111111111 # Trakt API client ID. Create an app at https://trakt.tv/oauth/applications/new and copy the client ID
-    client_secret: aaaaaaa111111111  # Trakt API client secret. Create an app at https://trakt.tv/oauth/applications/new and copy the client secret
   letterboxd:
     enabled: true
     imdb_id_filter: true # Uses the imdb id for better matching. This does slow the script down though!
@@ -70,6 +45,15 @@ plugins:
     enabled: true
     list_ids:
       - 1000-greatest-films
+  trakt:
+    enabled: false
+    list_ids:
+      - "movies/boxoffice"
+      - "shows/popular"
+      - walt-disney-animated-feature-films
+      - "20124699"   # Custom list ID for a user's list. Peek at the HTML source of the list page to find <input id="list-id" type="hidden" value="20124699">
+    client_id: aaaaaaa111111111 # Trakt API client ID. Create an app at https://trakt.tv/oauth/applications/new and copy the client ID
+    client_secret: aaaaaaa111111111  # Trakt API client secret. Create an app at https://trakt.tv/oauth/applications/new and copy the client secret
   arr:
     enabled: false
     server_configs:

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -31,6 +31,31 @@ plugins:
       - ls055592025
       - ls068305490
       - ls087301829
+  trakt:
+    enabled: false
+    clear_poster: true      #Clears poster before importing items (causes new generation)
+    clear_collection: true  #Clears collection before importing items
+    max_items: 20           #Sets a limit of the number of items pulled from Trakt. It does not take into account if finds a match for the item. if not set it pulls all.
+    list_ids:
+      - movies/trending     #The most watched movies right now.
+      - movies/popular      #The most popular movies of all time.
+      - movies/favorited    #The most favorited movies for the last week.
+      - movies/watched      #The most watched movies for the last week.
+      - movies/collected    #The most collected movies for the last week.
+      - movies/played       #The most played movies for the last week.
+      - movies/anticipated  #The most anticipated movies based on the number of lists a movie appears on.
+      - movies/boxoffice    #The top 10 movies in the US box office last weekend.
+      - shows/trending      #The most watched shows right now.
+      - shows/popular       #The most popular shows of all time. Popularity is calculated using the rating percentage and the number of ratings.
+      - shows/favorited     #The most favorited shows for the last week.
+      - shows/watched       #The most watched shows for the last week.
+      - shows/collected     #Most Collected Shows
+      - shows/played        #The most played (a single user can watch multiple episodes multiple times) shows for the last week.
+      - shows/anticipated   #The most anticipated shows based on the number of lists a show appears on.
+      - users/draackje/lists/pixar-feature-films # Add user lists by adding the last part of the url (if private it has to be the same user that has the api)
+      #- 20124699          # Custom list ID for a user's list. (deprecated)
+    client_id: aaaaaaa111111111 # Trakt API client ID. Create an app at https://trakt.tv/oauth/applications/new and copy the client ID
+    client_secret: aaaaaaa111111111  # Trakt API client secret. Create an app at https://trakt.tv/oauth/applications/new and copy the client secret
   letterboxd:
     enabled: true
     imdb_id_filter: true # Uses the imdb id for better matching. This does slow the script down though!
@@ -45,15 +70,6 @@ plugins:
     enabled: true
     list_ids:
       - 1000-greatest-films
-  trakt:
-    enabled: false
-    list_ids:
-      - "movies/boxoffice"
-      - "shows/popular"
-      - walt-disney-animated-feature-films
-      - "20124699"   # Custom list ID for a user's list. Peek at the HTML source of the list page to find <input id="list-id" type="hidden" value="20124699">
-    client_id: aaaaaaa111111111 # Trakt API client ID. Create an app at https://trakt.tv/oauth/applications/new and copy the client ID
-    client_secret: aaaaaaa111111111  # Trakt API client secret. Create an app at https://trakt.tv/oauth/applications/new and copy the client secret
   arr:
     enabled: false
     server_configs:

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ from loguru import logger
 from pyaml_env import parse_config
 import os
 import sys
+import time
 
 from apscheduler.schedulers.blocking import BlockingScheduler
 from apscheduler.triggers.cron import CronTrigger
@@ -77,6 +78,17 @@ def main(config):
 
                 # Match list items to jellyfin items
                 list_info = plugins[plugin_name].get_list(list_id, config['plugins'][plugin_name])
+                
+                # check if list is empty or returns None
+                if list_info is None or not list_info.get("items"):
+                    logger.warning(f"Skipping {list_id} because no data was returned.")
+                    continue
+
+                # Simple max items logic for all plugins.
+                max_items = config['plugins'][plugin_name].get("max_items")
+                if max_items and len(list_info['items']) > max_items:
+                    logger.info(f"Applying limit of {max_items} items to {list_id}")
+                    list_info['items'] = list_info['items'][:max_items]
 
                 # Find jellyfin collection or create it
                 collection_id = jf_client.find_collection_with_name_or_create(
@@ -86,9 +98,17 @@ def main(config):
                     plugin_name
                 )
 
+                # Give Jellyfin a moment to create the XML file if it's brand new
+                time.sleep(2)
+
                 if config["plugins"][plugin_name].get("clear_collection", False):
                     # Optionally clear everything from the collection first
                     jf_client.clear_collection(collection_id)
+                    time.sleep(5)
+
+                if config["plugins"][plugin_name].get("clear_poster", False):
+                    # Optionally clear poster
+                    jf_client.delete_poster(collection_id)
 
                 # Add items to the collection
                 for item in list_info['items']:
@@ -98,6 +118,7 @@ def main(config):
                         year_filter=config["plugins"][plugin_name].get("year_filter", True),
                         jellyfin_query_parameters=config["jellyfin"].get("query_parameters", {})
                     )
+                    time.sleep(1)
                     if not matched and js_client is not None:
                         js_client.make_request(item)
 
@@ -105,7 +126,10 @@ def main(config):
                 if not jf_client.has_poster(collection_id):
                     logger.info("Collection has no poster - generating one")
                     jf_client.make_poster(collection_id, list_info["name"])
-
+                # Pause for 2 seconds between processing different lists. This prevents hitting Rate Limits on Jellyfin/Jellyseerr 
+                # and allows the database to finish writing before the next sync.
+                logger.debug("Finished list. 2-second sleep")
+                time.sleep(2)
 
 
 if __name__ == "__main__":

--- a/utils/jellyfin.py
+++ b/utils/jellyfin.py
@@ -5,7 +5,7 @@ from base64 import b64encode
 import json
 import concurrent.futures
 from .poster_generation import fetch_collection_posters, safe_download, create_mosaic, get_font
-
+import time
 
 class JellyfinClient:
 
@@ -103,7 +103,16 @@ class JellyfinClient:
         if r.status_code == 404:
             return False
         return True
-
+    
+    def delete_poster(self, collection_id: str):
+        '''Deletes the primary image (poster) from a collection'''
+        logger.info(f"Clearing existing poster for collection {collection_id}")
+        
+        r = requests.delete(
+            f"{self.server_url}/Items/{collection_id}/Images/Primary", 
+            headers={"X-Emby-Token": self.api_key}
+        )
+        return r.status_code in [200, 204]
 
     def make_poster(self, collection_id, collection_name, mosaic_limit=20, google_font_url="https://fonts.googleapis.com/css2?family=Dosis:wght@800&display=swap"):
 
@@ -199,16 +208,21 @@ class JellyfinClient:
                 logger.error(f"Error adding {item['title']} to collection - JSONDecodeError")
         return False
 
-
-
     def clear_collection(self, collection_id: str):
         '''Clears a collection by removing all items from it'''
         res = requests.get(f'{self.server_url}/Users/{self.user_id}/Items',headers={"X-Emby-Token": self.api_key}, params={"Recursive": "true", "parentId": collection_id})
-        all_ids = [item["Id"] for item in res.json()["Items"]]
+        
+        items = res.json().get("Items", [])
+        if not items:
+            logger.debug(f"Collection {collection_id} is already empty. Skipping clear.")
+            return
+
+        all_ids = [item["Id"] for item in items]
 
         # chunk ids into groups of 10
         all_ids = [all_ids[i:i + 10] for i in range(0, len(all_ids), 10)]
         for ids in all_ids:
-             requests.delete(f'{self.server_url}/Collections/{collection_id}/Items',headers={"X-Emby-Token": self.api_key}, params={"ids": ",".join(ids)})
+            requests.delete(f'{self.server_url}/Collections/{collection_id}/Items',headers={"X-Emby-Token": self.api_key}, params={"ids": ",".join(ids)})
+            time.sleep(0.5) 
 
         logger.info(f"Cleared collection {collection_id}")


### PR DESCRIPTION
### Updates to `main.py` and `jellyfin.py`  to prevent jellyfin database panic, added fallback logic for plugins that fail, and added remove image functionality.

Prevent jellyfin database panic:
The main issue is that the request to jellyfin are sent too fast, and jellyfin is returning a "success" even when its not really done doing the task. This causes a stacking of requests and jellyfin tries to edit the same file at the same time. Adding a time.sleep after: 
jf_client.find_collection_with_name_or_create (2sec)
jf_client.add_item_to_collection (1sec)
between list runs (2sec)
between each group of 10 ids to be removed in clear_collection (0.5sec)

These times are really not well tested but it seems to be a sweet spot where jellyfin seems to not panic. Ofc this is really dependent on how quick your jellyfin server is... So it could be improved by adding some kind of logic to test jellyfin and setting the times based on that. But this works, and doesn't really slow things down too much. tries to address #123 

Added a fallback logic where if the list returns a empty or `none` the for loop stops gracefully. This has to be implemented in the plugins so that if they encounter errors they return `none` and it can continue even after failing. Addresses issue #100 

Added a max item check for the loop that arguably is a little simple but works. After having pulled all items it discards the ones that are more then the set amount. using `max_items: 50` in the config as the max items amount.

Added a clear poster functionality to remove poster before running a poster check. This is really handy for lists that are changing a lot.  Done by adding `clear_poster: true`. Its a bit of a frankenstein between the clear_collection and the poster creator.  This fixes #74 

Also added logic for clear colletion to handle already empty collections.

I am happy to add more/better explanations if needed :) 

This pull request is a part of a split of #136 