### PR TITLE
Fix and Improvements to Trakt plugin

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -31,6 +31,31 @@ plugins:
       - ls055592025
       - ls068305490
       - ls087301829
+  trakt:
+    enabled: false
+    clear_poster: true      #Clears poster before importing items (causes new generation)
+    clear_collection: true  #Clears collection before importing items
+    max_items: 20           #Sets a limit of the number of items pulled from Trakt. It does not take into account if finds a match for the item. if not set it pulls all.
+    list_ids:
+      - movies/trending     #The most watched movies right now.
+      - movies/popular      #The most popular movies of all time.
+      - movies/favorited    #The most favorited movies for the last week.
+      - movies/watched      #The most watched movies for the last week.
+      - movies/collected    #The most collected movies for the last week.
+      - movies/played       #The most played movies for the last week.
+      - movies/anticipated  #The most anticipated movies based on the number of lists a movie appears on.
+      - movies/boxoffice    #The top 10 movies in the US box office last weekend.
+      - shows/trending      #The most watched shows right now.
+      - shows/popular       #The most popular shows of all time. Popularity is calculated using the rating percentage and the number of ratings.
+      - shows/favorited     #The most favorited shows for the last week.
+      - shows/watched       #The most watched shows for the last week.
+      - shows/collected     #Most Collected Shows
+      - shows/played        #The most played (a single user can watch multiple episodes multiple times) shows for the last week.
+      - shows/anticipated   #The most anticipated shows based on the number of lists a show appears on.
+      - users/draackje/lists/pixar-feature-films # Add user lists by adding the last part of the url (if private it has to be the same user that has the api)
+      #- 20124699          # Custom list ID for a user's list. (deprecated)
+    client_id: aaaaaaa111111111 # Trakt API client ID. Create an app at https://trakt.tv/oauth/applications/new and copy the client ID
+    client_secret: aaaaaaa111111111  # Trakt API client secret. Create an app at https://trakt.tv/oauth/applications/new and copy the client secret
   letterboxd:
     enabled: true
     imdb_id_filter: true # Uses the imdb id for better matching. This does slow the script down though!
@@ -45,15 +70,6 @@ plugins:
     enabled: true
     list_ids:
       - 1000-greatest-films
-  trakt:
-    enabled: false
-    list_ids:
-      - "movies/boxoffice"
-      - "shows/popular"
-      - walt-disney-animated-feature-films
-      - "20124699"   # Custom list ID for a user's list. Peek at the HTML source of the list page to find <input id="list-id" type="hidden" value="20124699">
-    client_id: aaaaaaa111111111 # Trakt API client ID. Create an app at https://trakt.tv/oauth/applications/new and copy the client ID
-    client_secret: aaaaaaa111111111  # Trakt API client secret. Create an app at https://trakt.tv/oauth/applications/new and copy the client secret
   arr:
     enabled: false
     server_configs:

--- a/plugins/trakt.py
+++ b/plugins/trakt.py
@@ -66,7 +66,7 @@ class Trakt(ListScraper):
             },
             "shows/played": {
                 "title": "Most Played Shows",
-                "description": "Returns the most played (a single user can watch multiple episodes multiple times) shows for the last week."
+                "description": "The most played (a single user can watch multiple episodes multiple times) shows for the last week."
             },
             "shows/anticipated": {
                 "title": "Most Anticipated Shows",
@@ -93,15 +93,23 @@ class Trakt(ListScraper):
         else:
             # If we have not authenticated, get the access token from the user
             r = requests.post("https://api.trakt.tv/oauth/device/code", headers=headers, json={"client_id": config["client_id"]})
+            
+            # Ensure the API request was successful to prevent JSON parsing crashes.
+            # This safely catches errors like 429 (Rate Limit) or 401 (Bad Client ID).
+            if r.status_code != 200:
+                logger.error(f"Failed to get device code from Trakt! Status: {r.status_code}")
+                return None
+                
             device_code = r.json()["device_code"]
             user_code = r.json()["user_code"]
             interval = r.json()["interval"]
 
-            logger.info("Authentication with Trakt API required")
-            logger.info(f"Please visit the following URL to get your access token: {r.json()['verification_url']}")
-            logger.info("")
-            logger.info(f"Your device code is: {user_code}")
-            logger.info("")
+            # AUTHENTICATION PROMPT
+            logger.info("===================================================")
+            logger.info("🛑 AUTHENTICATION WITH TRAKT API REQUIRED 🛑")
+            logger.info(f"Please visit: {r.json()['verification_url']}")
+            logger.info(f"Enter this device code: {user_code}")
+            logger.info("===================================================")
 
             # Poll the API until the user has authenticated
             while True:
@@ -125,6 +133,9 @@ class Trakt(ListScraper):
 
     def get_list(list_id, config=None):
 
+        # Force user input to lowercase to prevent case-sensitive crashes
+        list_id = str(list_id).lower()
+
         headers = {
             "Content-Type": "application/json",
             "trakt-api-version": "2",
@@ -132,45 +143,106 @@ class Trakt(ListScraper):
         }
 
         access_token = Trakt._get_auth_token(config)
+        # If authentication failed, return an empty list structure
+        if not access_token:
+            return None
+            
         headers["Authorization"] = f"Bearer {access_token}"
         logger.debug("Access token loaded")
+        item_types = "movie" # Default fallback
 
         if list_id.startswith("users/"):
-            logger.debug("Trakt Default User list")
+            logger.debug(f"Trakt User list via slug: {list_id}")
+            # Get Metadata
             r = requests.get(f"https://api.trakt.tv/{list_id}", headers=headers)
-            components = list_id.split("/")
-            list_name = f"{components[1]}'s {components[2]}"
-            description = f"{components[1]}'s {components[2]}"
-            items_data = r.json()
+            if r.status_code != 200:
+                logger.error(f"Trakt user list '{list_id}' not found! Status: {r.status_code}")
+                return None
+            
+            list_data = r.json()
+            list_name = list_data.get("name", "User List")
+            description = list_data.get("description", "")
+            
+            # Get Items
+            r = requests.get(f"https://api.trakt.tv/{list_id}/items", headers=headers)
+            items_data = r.json() if r.status_code == 200 else []
         elif list_id.startswith("shows/") or list_id.startswith("movies/"):
             # Chart
             logger.debug("Trakt chart list")
-
-            current_page = 1
-            items_data = []
-            while True:
-                r = requests.get(f"https://api.trakt.tv/{list_id}?page={current_page}", headers=headers)
-                items_data += r.json()
-                page_count = int(r.headers.get("X-Pagination-Page-Count", 1))
-                logger.debug(f"Page {current_page}/{page_count}")
-                if current_page >= page_count:
-                    break
-                current_page += 1
-
+            # Retrieve collection metadata based on the chart type.
             list_name = Trakt._chart_types[list_id]["title"]
             description = Trakt._chart_types[list_id]["description"]
+            # Establish the default media type for parsing items below. (Fallback if Trakt doesnt provide)
             if list_id.startswith("shows/"):
                 item_types = "show"
             else:
                 item_types = "movie"
-        else:
-            logger.debug("Trakt User list")
-            r = requests.get(f"https://api.trakt.tv/lists/{list_id}", headers=headers)
-            list_name = r.json()["name"]
-            description = r.json()["description"]
-            r = requests.get(f"https://api.trakt.tv/lists/{list_id}/items", headers=headers)
-            items_data = r.json()
 
+            current_page = 1
+            items_data = []
+            max_items = config.get("max_items") if config else None
+
+            while True:
+                r = requests.get(f"https://api.trakt.tv/{list_id}?page={current_page}", headers=headers)
+                # Catch formal API errors (e.g., 429 Too Many Requests, 500 Server Error).
+                if r.status_code != 200:
+                    logger.error(f"Trakt API error (Status {r.status_code}) on page {current_page}.")
+                    break
+                # Safely try to read the JSON. This catches edge cases where Trakt returns a 200 OK status but serves an HTML Cloudflare page instead.
+                try:
+                    page_data = r.json()
+                except Exception as e:
+                    logger.error(f"Trakt returned invalid JSON on page {current_page}. Stopping pagination.")
+                    break
+
+                items_data += page_data
+                page_count = int(r.headers.get("X-Pagination-Page-Count", 1))
+                # Massive lists (like movies/watched) have tens of thousands of pages. Warn the user if they didn't set a limit so they know why it takes hours.
+                if current_page == 1 and max_items is None and page_count > 50:
+                    est_hours = round(page_count / 3600, 2)
+                    logger.warning(f"WARNING: No 'max_items' limit set for {list_id}!")
+                    logger.warning(f"Trakt reports {page_count} total pages. Due to API rate limits, this will take approximately {est_hours} hours to fetch.")
+                    logger.warning("If it appears 'stuck', it is just working slowly in the background.")
+                    logger.warning("Recommendation: Add 'max_items: 1000' (or similar) to your config.yaml to prevent this.")
+                logger.debug(f"Page {current_page}/{page_count}. Total items: {len(items_data)}")
+                # Stop paginating if we reach the end of Trakt's list OR hit the user's configured limit.
+                if current_page >= page_count or (max_items is not None and len(items_data) >= max_items):
+                    break
+                current_page += 1
+                # Pause for 1 second between requests to respect Trakt's rate limits.
+                time.sleep(1)
+            # We fetch in full pages, so we might have slightly overshot the limit. Slice the final array to return the exact number the user requested.
+            if max_items is not None:
+                items_data = items_data[:max_items]
+        else:
+            # CUSTOM USER LIST
+            logger.debug(f"Trakt User list: {list_id}")
+            
+            r = requests.get(f"https://api.trakt.tv/lists/{list_id}", headers=headers)
+            
+            # Safety check: If list is private or ID is wrong, Trakt returns 404 or 401
+            if r.status_code != 200:
+                logger.error(f"Trakt list '{list_id}' not found or private (Status {r.status_code}). Skipping.")
+                return None
+
+            try:
+                list_data = r.json()
+                list_name = list_data.get("name", "Unknown List")
+                description = list_data.get("description", "")
+            except Exception:
+                logger.error(f"Failed to parse metadata for Trakt list '{list_id}'.")
+                return None
+
+            # Fetch the Items
+            r = requests.get(f"https://api.trakt.tv/lists/{list_id}/items", headers=headers)
+            if r.status_code == 200:
+                try:
+                    items_data = r.json()
+                except Exception:
+                    items_data = []
+            else:
+                logger.warning(f"Could not fetch items for list '{list_id}'.")
+                items_data = []
 
         # Process the items
         logger.debug("Processing items.")
@@ -192,14 +264,15 @@ class Trakt(ListScraper):
 
             if "imdb" in meta["ids"]:
                 item["imdb_id"] = meta["ids"]["imdb"]
-            try:
+            
+            if "title" in meta:
                 item["title"] = meta["title"]
-            except:
-                breakpoint()
+            else:
+                continue
             if "year" in meta:
                 item["release_year"] = meta["year"]
             items.append(item)
-
+            
         return {
             "name": list_name,
             "description": description,


### PR DESCRIPTION
### Fix and Improvements to Trakt plugin

Based on the new API documentation:
[Trakt API Documentation](https://trakt.docs.apiary.io)

Rearranged Config.example to have trakt at the top and have all available lists. (its important that trakt is at the top so that the authentication is catched by the user.)
Also commented out the list numeric id as this is no longer easily available to users. 

Added graceful fallback to `none` if authentication fails.

Updated authentication prompt to be more visually noticeable for users.

 Added to.lower for the list name to not cause issues with users having them in the wrong "style"

Added graceful fallback for error when getting access_token to `none`.

Set a default item_type to stop errors caused by trakt not giving them.

Handled the "URL vs ID" mess: I updated the logic so you can just grab a list slug from the URL (like users/me/lists/watchlist) or use the numeric ID. So that for users that still have the numeric id it works as before. But as trakt no longer gives this id out easily I have implemented the trak api way [User Lists](https://trakt.docs.apiary.io/#reference/users/lists/get-a-user's-personal-lists) 

The biggest issue with how trakt was handled previously was that with the change in how the api works Trakt now exposes a huge list, can be several 1000 items, and with a free api key that hits the api limit really fast causing trakt to give a error that would previously crash the python script. Thats why i have incorperated a more sofisticated version of `max_items` that limits the amount of pages the function runs. I have also added a fallback in the case where trakt gives an error. I have also added a warning in logs to explain the issue with adding thousands of items to a collection. With a time estimate for running the list without a max items set.

I have also added a time pause (1sec) between the requests to trakt to keep within the limits of the service: [Rate-Limiting](https://trakt.docs.apiary.io/#introduction/rate-limiting) 

Removed Breakpoint() as its destructive in its failing, better handled now.

Please let me know if anything is unclear :) 

Fixes #118 
This pull request is a part of a split of #136 
It needs #137 to function properly.