### PR TITLE
Add safety checks to IMDb plugins

### DIFF
--- a/plugins/imdb_chart.py
+++ b/plugins/imdb_chart.py
@@ -10,12 +10,18 @@ class IMDBChart(ListScraper):
     def get_list(list_id, config=None):
         res = requests.get(f'https://www.imdb.com/chart/{list_id}', headers={'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:145.0) Gecko/20100101 Firefox/145.0', 'Accept-Language': 'en-US'})
         soup = bs4.BeautifulSoup(res.text, 'html.parser')
-        list_name = soup.find('title').text
+        
+        # Check if IMDb blocked the request or returned an empty/challenge page
+        title_tag = soup.find('title')
+        data_tag = soup.find('script', id='__NEXT_DATA__')
+        if not title_tag or not data_tag:
+            return None
+
+        list_name = title_tag.text
         description = soup.find('meta', property='og:description')['content']
         movies = []
 
-        data = soup.find('script', id='__NEXT_DATA__')
-        data = json.loads(data.text)
+        data = json.loads(data_tag.text)
 
         for movie in next(iter(data["props"]["pageProps"]["pageData"].values()))["edges"]:
             movie = movie["node"]
@@ -23,7 +29,12 @@ class IMDBChart(ListScraper):
                 # Get item details
                 res = requests.get(f'https://www.imdb.com/title/{movie["release"]["titles"][0]["id"]}', headers={'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:145.0) Gecko/20100101 Firefox/145.0'})
                 soup = bs4.BeautifulSoup(res.text, 'html.parser')
-                item_data = json.loads(soup.find('script', id='__NEXT_DATA__').text)
+                
+                item_script = soup.find('script', id='__NEXT_DATA__')
+                if not item_script:
+                    continue
+                
+                item_data = json.loads(item_script.text)
                 movie = item_data["props"]["pageProps"]["aboveTheFoldData"]
 
             title = movie["titleText"]["text"]

--- a/plugins/imdb_list.py
+++ b/plugins/imdb_list.py
@@ -10,11 +10,21 @@ class IMDBList(ListScraper):
     def get_list(list_id, config=None):
         r = requests.get(f'https://www.imdb.com/list/{list_id}', headers={'Accept-Language': 'en-US', 'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:145.0) Gecko/20100101 Firefox/145.0', 'Accept-Language': 'en-US'})
         soup = bs4.BeautifulSoup(r.text, 'html.parser')
-        list_name = soup.find('h1').text
-        description = soup.find("div", {"class": "list-description"}).text
+        
+        # Check if elements exist before accessing .text
+        header_tag = soup.find('h1')
+        json_script = soup.find("script", {"type": "application/ld+json"})
+        
+        if not header_tag or not json_script:
+            return None
 
-        ld_json = soup.find("script", {"type": "application/ld+json"}).text
-        ld_json = json.loads(ld_json)
+        list_name = header_tag.text
+        
+        # Safe check for description
+        desc_tag = soup.find("div", {"class": "list-description"})
+        description = desc_tag.text if desc_tag else ""
+
+        ld_json = json.loads(json_script.text)
         movies = []
         for row in ld_json["itemListElement"]:
             url_parts = row["item"]["url"].split("/")
@@ -23,10 +33,13 @@ class IMDBList(ListScraper):
             release_year = None
             if config.get("add_release_year", False):
                 # Get release_date
-                r = requests.get(row["item"]["url"], headers={'Accept-Language': 'en-US', 'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:145.0) Gecko/20100101 Firefox/145.0', 'Accept-Language': 'en-US'})
-                soup = bs4.BeautifulSoup(r.text, 'html.parser')
-                movie_json = soup.find("script", {"type": "application/ld+json"}).text
-                release_year = json.loads(movie_json)["datePublished"].split("-")[0]
+                r_item = requests.get(row["item"]["url"], headers={'Accept-Language': 'en-US', 'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:145.0) Gecko/20100101 Firefox/145.0'})
+                soup_item = bs4.BeautifulSoup(r_item.text, 'html.parser')
+                
+                item_script = soup_item.find("script", {"type": "application/ld+json"})
+                if item_script:
+                    movie_json = json.loads(item_script.text)
+                    release_year = movie_json.get("datePublished", "").split("-")[0]
 
             movies.append({
                 "title": row["item"]["name"],


### PR DESCRIPTION
This is a bit of a quick fix for IMDB not working properly for me anymore, I dont know if its just my IP being blocked or a change in how IMDB catches scrapers.

It really just adding a few checks before running the original script to handle errors gracefully. Using the `none` function added in #137 

its mostly .text that fails so ive had to split them, because its necessary to check if it has a value before using .text

Please ask questions :)

Needs #137 to function properly. 
A part of the split of pull #136 