### PR TITLE
Add request timeouts and safer poster downloads

### DIFF
--- a/plugins/arr.py
+++ b/plugins/arr.py
@@ -1,5 +1,5 @@
 import bs4
-import requests
+from utils import http_client as requests
 import json
 from utils.base_plugin import ListScraper
 from loguru import logger

--- a/plugins/bfi.py
+++ b/plugins/bfi.py
@@ -2,7 +2,7 @@ import yaml
 import re
 from utils.base_plugin import ListScraper
 import bs4
-import requests
+from utils import http_client as requests
 from loguru import logger
 
 class BFI(ListScraper):

--- a/plugins/criterion.py
+++ b/plugins/criterion.py
@@ -1,7 +1,7 @@
 import json
 from utils.base_plugin import ListScraper
 import bs4
-import requests
+from utils import http_client as requests
 from loguru import logger
 #from requests_cache import CachedSession, FileCache
 

--- a/plugins/imdb_chart.py
+++ b/plugins/imdb_chart.py
@@ -1,5 +1,5 @@
 import bs4
-import requests
+from utils import http_client as requests
 from utils.base_plugin import ListScraper
 import json
 

--- a/plugins/imdb_list.py
+++ b/plugins/imdb_list.py
@@ -1,5 +1,5 @@
 import bs4
-import requests
+from utils import http_client as requests
 import json
 from utils.base_plugin import ListScraper
 

--- a/plugins/jellyfin_api.py
+++ b/plugins/jellyfin_api.py
@@ -1,5 +1,5 @@
 import bs4
-import requests
+from utils import http_client as requests
 import json
 from utils.base_plugin import ListScraper
 

--- a/plugins/listmania.py
+++ b/plugins/listmania.py
@@ -1,7 +1,7 @@
 import yaml
 from utils.base_plugin import ListScraper
 import bs4
-import requests
+from utils import http_client as requests
 from loguru import logger
 
 class ListMania(ListScraper):

--- a/plugins/mdblist.py
+++ b/plugins/mdblist.py
@@ -1,7 +1,7 @@
 import json
 from utils.base_plugin import ListScraper
 import bs4
-import requests
+from utils import http_client as requests
 
 class MDBList(ListScraper):
 

--- a/plugins/popular_movies.py
+++ b/plugins/popular_movies.py
@@ -1,5 +1,5 @@
 import json
-import requests
+from utils import http_client as requests
 
 from utils.base_plugin import ListScraper
 

--- a/plugins/trakt.py
+++ b/plugins/trakt.py
@@ -2,7 +2,7 @@ import json
 from utils.base_plugin import ListScraper
 import bs4
 import os
-import requests
+from utils import http_client as requests
 from loguru import logger
 import time
 

--- a/plugins/tspdt.py
+++ b/plugins/tspdt.py
@@ -1,7 +1,7 @@
 import json
 from utils.base_plugin import ListScraper
 import bs4
-import requests
+from utils import http_client as requests
 
 class TSPDT(ListScraper):
 

--- a/tests/test_utils/test_http_client.py
+++ b/tests/test_utils/test_http_client.py
@@ -1,0 +1,65 @@
+from utils import http_client
+
+
+def test_get_applies_default_timeout(monkeypatch):
+    seen = {}
+
+    def fake_get(url, **kwargs):
+        seen["url"] = url
+        seen["kwargs"] = kwargs
+        return object()
+
+    monkeypatch.setattr(http_client.requests, "get", fake_get)
+
+    http_client.get("https://example.test")
+
+    assert seen["url"] == "https://example.test"
+    assert seen["kwargs"]["timeout"] == http_client.DEFAULT_TIMEOUT
+
+
+def test_get_preserves_explicit_timeout(monkeypatch):
+    seen = {}
+
+    def fake_get(url, **kwargs):
+        seen["kwargs"] = kwargs
+        return object()
+
+    monkeypatch.setattr(http_client.requests, "get", fake_get)
+
+    http_client.get("https://example.test", timeout=(1, 2))
+
+    assert seen["kwargs"]["timeout"] == (1, 2)
+
+
+def test_session_applies_default_timeout(monkeypatch):
+    seen = {}
+
+    def fake_request(self, method, url, **kwargs):
+        seen["method"] = method
+        seen["url"] = url
+        seen["kwargs"] = kwargs
+        return object()
+
+    monkeypatch.setattr(http_client.requests.Session, "request", fake_request)
+
+    session = http_client.Session()
+    session.get("https://example.test")
+
+    assert seen["method"] == "GET"
+    assert seen["url"] == "https://example.test"
+    assert seen["kwargs"]["timeout"] == http_client.DEFAULT_TIMEOUT
+
+
+def test_session_preserves_explicit_timeout(monkeypatch):
+    seen = {}
+
+    def fake_request(self, method, url, **kwargs):
+        seen["kwargs"] = kwargs
+        return object()
+
+    monkeypatch.setattr(http_client.requests.Session, "request", fake_request)
+
+    session = http_client.Session()
+    session.post("https://example.test", timeout=(2, 4))
+
+    assert seen["kwargs"]["timeout"] == (2, 4)

--- a/tests/test_utils/test_poster_generation.py
+++ b/tests/test_utils/test_poster_generation.py
@@ -1,0 +1,76 @@
+from io import BytesIO
+
+import pytest
+from PIL import Image
+
+from utils import poster_generation
+
+
+class FakeResponse:
+    def __init__(self, body, headers=None):
+        self.body = body
+        self.headers = headers or {}
+
+    def raise_for_status(self):
+        pass
+
+    def iter_content(self, chunk_size=8192):
+        for index in range(0, len(self.body), chunk_size):
+            yield self.body[index:index + chunk_size]
+
+
+def image_bytes(image_format):
+    output = BytesIO()
+    Image.new("RGB", (1, 1), "red").save(output, format=image_format)
+    return output.getvalue()
+
+
+@pytest.mark.parametrize(
+    ("image_format", "content_type"),
+    [
+        ("JPEG", "image/jpeg"),
+        ("PNG", "image/png"),
+        ("WEBP", "image/webp"),
+    ],
+)
+def test_download_image_accepts_expected_formats(monkeypatch, image_format, content_type):
+    body = image_bytes(image_format)
+
+    def fake_get(url, **kwargs):
+        assert kwargs["stream"] is True
+        return FakeResponse(body, {"Content-Type": content_type})
+
+    monkeypatch.setattr(poster_generation.requests, "get", fake_get)
+
+    image = poster_generation.download_image("https://example.test/poster", {})
+
+    assert image.mode == "RGB"
+    assert image.size == (1, 1)
+
+
+def test_safe_download_rejects_non_image_content_type_before_decode(monkeypatch):
+    def fake_get(url, **kwargs):
+        return FakeResponse(b"not an image", {"Content-Type": "text/plain"})
+
+    def fail_open(*args, **kwargs):
+        raise AssertionError("Image.open should not be called")
+
+    monkeypatch.setattr(poster_generation.requests, "get", fake_get)
+    monkeypatch.setattr(poster_generation.Image, "open", fail_open)
+
+    assert poster_generation.safe_download("https://example.test/poster", {}) is None
+
+
+def test_safe_download_rejects_oversized_image_before_decode(monkeypatch):
+    headers = {"Content-Length": str(poster_generation.MAX_POSTER_DOWNLOAD_BYTES + 1)}
+
+    def fake_get(url, **kwargs):
+        return FakeResponse(b"", headers)
+
+    def fail_open(*args, **kwargs):
+        raise AssertionError("Image.open should not be called")
+
+    monkeypatch.setattr(poster_generation.requests, "get", fake_get)
+    monkeypatch.setattr(poster_generation.Image, "open", fail_open)
+
+    assert poster_generation.safe_download("https://example.test/poster", {}) is None

--- a/utils/http_client.py
+++ b/utils/http_client.py
@@ -1,0 +1,28 @@
+import requests
+
+
+DEFAULT_TIMEOUT = (5, 30)
+
+exceptions = requests.exceptions
+
+
+def _with_timeout(kwargs):
+    kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
+    return kwargs
+
+
+def get(url, **kwargs):
+    return requests.get(url, **_with_timeout(kwargs))
+
+
+def post(url, **kwargs):
+    return requests.post(url, **_with_timeout(kwargs))
+
+
+def delete(url, **kwargs):
+    return requests.delete(url, **_with_timeout(kwargs))
+
+
+class Session(requests.Session):
+    def request(self, method, url, **kwargs):
+        return super().request(method, url, **_with_timeout(kwargs))

--- a/utils/jellyfin.py
+++ b/utils/jellyfin.py
@@ -1,4 +1,4 @@
-import requests
+from utils import http_client as requests
 import html
 from loguru import logger
 from base64 import b64encode

--- a/utils/jellyseerr.py
+++ b/utils/jellyseerr.py
@@ -1,4 +1,4 @@
-import requests
+from utils import http_client as requests
 import urllib.parse
 from loguru import logger
 

--- a/utils/poster_generation.py
+++ b/utils/poster_generation.py
@@ -1,5 +1,5 @@
 import os
-import requests
+from utils import http_client as requests
 from loguru import logger
 from PIL import Image, ImageDraw, ImageFont, ImageFilter, ImageOps
 import math

--- a/utils/poster_generation.py
+++ b/utils/poster_generation.py
@@ -14,6 +14,8 @@ LINE_SPACING = 25
 SHADOW_SIZE = 8
 BACKGROUND_COLOR = (0, 0, 0)
 OVERLAY_PADDING = 50
+MAX_POSTER_DOWNLOAD_BYTES = 10 * 1024 * 1024
+ALLOWED_IMAGE_FORMATS = ["JPEG", "PNG", "WEBP"]
 
 def get_font(url, font_dir="./fonts"):
     '''Download ttf from google font css'''
@@ -77,10 +79,45 @@ def download_image(url, headers):
     """
     Downloads an image from a URL and returns a Pillow Image object.
     """
-    response = requests.get(url, headers=headers)
+    response = requests.get(url, headers=headers, stream=True)
     response.raise_for_status()
-    image = Image.open(BytesIO(response.content)).convert("RGB")
-    return image
+    _validate_image_response(response)
+    image_data = _read_limited_response(response, MAX_POSTER_DOWNLOAD_BYTES)
+    with Image.open(BytesIO(image_data), formats=ALLOWED_IMAGE_FORMATS) as image:
+        if image.format not in ALLOWED_IMAGE_FORMATS:
+            raise ValueError(f"Unsupported image format: {image.format}")
+        return image.convert("RGB")
+
+
+def _validate_image_response(response):
+    content_type = response.headers.get("Content-Type", "").split(";")[0].strip().lower()
+    if content_type and not content_type.startswith("image/"):
+        raise ValueError(f"Unsupported content type: {content_type}")
+
+    content_length = response.headers.get("Content-Length")
+    if content_length is None:
+        return
+
+    try:
+        size = int(content_length)
+    except ValueError:
+        return
+
+    if size > MAX_POSTER_DOWNLOAD_BYTES:
+        raise ValueError(f"Image download is too large: {size} bytes")
+
+
+def _read_limited_response(response, max_bytes):
+    chunks = []
+    total = 0
+    for chunk in response.iter_content(chunk_size=8192):
+        if not chunk:
+            continue
+        total += len(chunk)
+        if total > max_bytes:
+            raise ValueError(f"Image download exceeded {max_bytes} bytes")
+        chunks.append(chunk)
+    return b"".join(chunks)
 
 
 # --- Text and Font Functions ---


### PR DESCRIPTION
This adds a small shared HTTP wrapper so requests do not hang forever, then uses it across the plugins and Jellyfin helpers that call external services. It also tightens poster downloads by streaming them with a size limit and basic image checks, which should make bad or oversized remote responses fail gracefully instead of tying up the sync or feeding arbitrary data straight into Pillow.