### PR TITLE
Harden Docker image and publishing config

### DIFF
--- a/.github/workflows/push_to_docker.yml
+++ b/.github/workflows/push_to_docker.yml
@@ -2,18 +2,21 @@ name: Publish Docker image
 on:
   push:
     branches: [master]
+permissions:
+  contents: read
+  packages: write
 jobs:
   multi_push_to_registry:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -24,7 +27,7 @@ jobs:
         env:
           OWNER: '${{ github.repository_owner }}'
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
         with:
           context: .
           file: ./Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,12 @@ RUN pip install -r requirements.txt
 FROM build as final
 
 WORKDIR /app
-COPY --from=build /app /app
+RUN addgroup -S app && adduser -S -G app app \
+    && mkdir -p /app/config /app/fonts \
+    && chown -R app:app /app /tmp
 
 VOLUME [ "/app/config" ]
+
+USER app
 
 ENTRYPOINT [ "python3.10", "-u", "main.py", "--config", "/app/config/config.yaml" ]

--- a/README.md
+++ b/README.md
@@ -61,12 +61,14 @@ Then run `python main.py`.
 
 ### Docker
 
-The easiest way to get going is to use the provided `docker-compose.yml` configuration. Whatever directory you end up mapping to the `/app/config` directory needs to contain your updated `config.yaml` file:
+The easiest way to get going is to use the provided `docker-compose.yml` configuration. Whatever directory you end up mapping to the `/app/config` directory needs to contain your updated `config.yaml` file.
+
+Set `JELLYFIN_AUTO_COLLECTIONS_IMAGE_REF` to a reviewed commit-SHA tag or digest before deploying. Do not use the mutable `latest` tag for unattended deployments.
 
 ```yaml
 services:
   jellyfin-auto-collections:
-    image: ghcr.io/ghomashudson/jellyfin-auto-collections:latest
+    image: ${JELLYFIN_AUTO_COLLECTIONS_IMAGE_REF:?set to a reviewed commit-SHA tag or digest, not latest}
     container_name: jellyfin-auto-collections
     environment:
       - CRONTAB=0 0 * * *

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   jellyfin-auto-collections:
     #build: .
-    image: ghcr.io/ghomashudson/jellyfin-auto-collections:latest
+    image: ${JELLYFIN_AUTO_COLLECTIONS_IMAGE_REF:?set to a reviewed commit-SHA tag or digest, not latest}
     container_name: jellyfin-auto-collections
     environment:
       - CRONTAB=0 0 * * *


### PR DESCRIPTION
This makes the container run as a non-root user and updates the Docker examples so users pin image tags instead of pulling a moving latest image. It also pins the GitHub Actions used for image publishing, which keeps the build pipeline more predictable and avoids taking unreviewed action changes automatically.