### PR TITLE
Replace pluginlib with local plugin loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ config.yaml
 __pycache__
 .trakt_access_token
 .letterboxd_cache.json
+.DS_Store

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 from typing import cast
 from utils.jellyfin import JellyfinClient
 from utils.jellyseerr import JellyseerrClient
-import pluginlib
+from utils.plugin_loader import load_plugins
 from loguru import logger
 from pyaml_env import parse_config
 import os
@@ -48,8 +48,7 @@ def main(config):
         js_client = None
 
     # Load plugins
-    loader = pluginlib.PluginLoader(modules=['plugins'])
-    plugins = loader.plugins['list_scraper']
+    plugins = load_plugins()
 
     # If Jellyfin_api plugin is enabled - pass the jellyfin creds to it
     if "jellyfin_api" in config["plugins"] and config["plugins"]["jellyfin_api"].get("enabled", False):

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -3,12 +3,12 @@
 Each of these files implements the [base_plugin.py](https://github.com/ghomasHudson/Jellyfin-Auto-Collections/blob/master/utils/base_plugin.py) base class:
 
 ```python
-import pluginlib
+from utils.base_plugin import ListScraper
 
-@pluginlib.Parent('list_scraper')
-class ListScraper(object):
+class MyPlugin(ListScraper):
 
-    @pluginlib.abstractmethod
+    _alias_ = "my_plugin"
+
     def get_list(list_id, config=None):
         pass
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,6 @@ parse==1.21.1
 pillow==11.1.0
 platformdirs==4.3.7
 pluggy==1.6.0
-pluginlib==0.9.2
 pyaml-env==1.2.1
 pycparser==3.0
 pyee==11.1.1
@@ -48,7 +47,6 @@ requests==2.32.3
 requests-cache==1.2.1
 requests-html==0.10.0
 rich==15.0.0
-setuptools==70.0.0
 six==1.16.0
 soupsieve==2.5
 termcolor==3.3.0

--- a/tests/test_utils/test_plugin_loader.py
+++ b/tests/test_utils/test_plugin_loader.py
@@ -1,0 +1,22 @@
+from utils.base_plugin import ListScraper
+from utils.plugin_loader import load_plugins
+
+
+def test_load_plugins_discovers_builtin_aliases():
+    plugins = load_plugins()
+
+    assert {
+        "arr",
+        "bfi",
+        "criterion_channel",
+        "imdb_chart",
+        "imdb_list",
+        "jellyfin_api",
+        "letterboxd",
+        "listmania",
+        "mdblist",
+        "popular_movies",
+        "trakt",
+        "tspdt",
+    }.issubset(plugins)
+    assert all(issubclass(plugin, ListScraper) for plugin in plugins.values())

--- a/utils/base_plugin.py
+++ b/utils/base_plugin.py
@@ -1,8 +1,10 @@
-import pluginlib
+from abc import ABC, abstractmethod
 
-@pluginlib.Parent('list_scraper')
-class ListScraper(object):
 
-    @pluginlib.abstractmethod
+class ListScraper(ABC):
+    _alias_ = None
+
+    @staticmethod
+    @abstractmethod
     def get_list(list_id, config=None):
         pass

--- a/utils/plugin_loader.py
+++ b/utils/plugin_loader.py
@@ -1,0 +1,34 @@
+import importlib
+import inspect
+import pkgutil
+
+from .base_plugin import ListScraper
+
+
+def load_plugins(package_name="plugins"):
+    package = importlib.import_module(package_name)
+    plugins = {}
+
+    for module_info in pkgutil.walk_packages(package.__path__, f"{package.__name__}."):
+        module = importlib.import_module(module_info.name)
+        for plugin_class in _iter_plugin_classes(module):
+            alias = getattr(plugin_class, "_alias_", None)
+            if not alias:
+                raise ValueError(f"Plugin {plugin_class.__name__} is missing _alias_")
+            if alias in plugins:
+                raise ValueError(f"Duplicate plugin alias: {alias}")
+            plugins[alias] = plugin_class
+
+    return plugins
+
+
+def _iter_plugin_classes(module):
+    for _, obj in inspect.getmembers(module, inspect.isclass):
+        if obj is ListScraper:
+            continue
+        if obj.__module__ != module.__name__:
+            continue
+        if inspect.isabstract(obj):
+            continue
+        if issubclass(obj, ListScraper):
+            yield obj


### PR DESCRIPTION
This removes the old `pluginlib` dependency and replaces it with a small local loader that discovers `ListScraper` subclasses from the plugins package. When I was updating setuptools that had the security flag I noticed that it dropped `pluginlib`. I could of pinned to `setuptools` to `80.10.2`. But this fix should allow the package to be updated in the future to patch other security issues.